### PR TITLE
Add sample_rate arg to allow user provide sampling rate manually

### DIFF
--- a/R/calibrate.R
+++ b/R/calibrate.R
@@ -14,6 +14,7 @@
 #' should the time course be trimmed for zero values at
 #' the beginning and the end of the time course?
 #' observation carried forward?
+#' @param sample_rate integer stating number of observations per second in the CSV file
 #'
 #'
 #' @return A set of calibration coefficients
@@ -37,6 +38,7 @@ estimate_calibration_values = function(file, verbose = TRUE,
                                        fill_in = TRUE,
                                        by_second = FALSE,
                                        trim = FALSE,
+                                       sample_rate = NULL,
                                        ...) {
 
   if (is.character(file) && grepl("[.]gt3x(|[.]gz)$", file)) {
@@ -63,7 +65,7 @@ estimate_calibration_values = function(file, verbose = TRUE,
     if (verbose) {
       message("Writing out file for GGIR")
     }
-    file = write_acc_csv(file)
+    file = write_acc_csv(file, sample_rate)
   }
   if (verbose) {
     message("Running g.inspectfile")
@@ -89,6 +91,7 @@ calibrate = function(file, verbose = TRUE,
                      fill_in = TRUE,
                      by_second = FALSE,
                      trim = FALSE,
+                     sample_rate = NULL,
                      round_after_calibration = TRUE,
                      ...) {
   if (is.character(file) && grepl("[.]gt3x(|[.]gz)$", file)) {
@@ -118,6 +121,7 @@ calibrate = function(file, verbose = TRUE,
     fill_in = fill_in,
     by_second = by_second,
     trim = trim,
+    sample_rate = sample_rate,
     ...)
 
   acc_data = is.AccData(file)

--- a/R/ggir_process.R
+++ b/R/ggir_process.R
@@ -10,6 +10,7 @@
 #' constructor are allowed.
 #' @param verbose print diagnostic messages
 #' @param calibrate Run calibration, passed to \code{do.calibrate} in \code{GGIR}
+#' @param sample_rate integer stating number of observations per second in the CSV file
 #' @param ... additional arguments to pass to \code{\link{g.shell.GGIR}}
 #'
 #' @return A list with all the output elements
@@ -30,7 +31,8 @@
 #' sum_data = dplyr::left_join(sum_data, m)
 #' cor(sum_data$ENMO, sum_data$ENMO_t)
 #' }
-ggir_process = function(df, unit = "1 min", calibrate = TRUE, verbose = TRUE, ...) {
+ggir_process = function(df, unit = "1 min", calibrate = TRUE, verbose = TRUE,
+                        sample_rate = NULL, ...) {
   tdir = tempfile()
   dir.create(tdir, recursive = TRUE)
 
@@ -43,7 +45,7 @@ ggir_process = function(df, unit = "1 min", calibrate = TRUE, verbose = TRUE, ..
   if (verbose) {
     message("Writing out file ", file)
   }
-  file = write_acc_csv(df, file = file)
+  file = write_acc_csv(df, file = file, sample_rate)
   rm(df)
 
   if (verbose) {

--- a/R/write_acc_csv.R
+++ b/R/write_acc_csv.R
@@ -2,6 +2,7 @@
 #'
 #' @param file CSV file to write out
 #' @param x either an \code{AccData} or a \code{data.frame} of time and values.
+#' @param sample_rate integer stating number of observations per second in the CSV
 #'
 #' @return The character path of the output file.
 #' @export
@@ -14,14 +15,14 @@
 #'    out2 = read_acc_csv(outfile)
 #'    all.equal(x$data, out2$data)
 #' }
-write_acc_csv = function(x, file = tempfile(fileext = ".csv.gz")) {
+write_acc_csv = function(x, file = tempfile(fileext = ".csv.gz"), sample_rate = NULL) {
   download_date = start_date = battery_voltage = firmware = NA
   # format_date =
   acc_data = is.AccData(x)
   if (acc_data) {
     header = x$header
   }
-  sample_rate = get_sample_rate(x)
+  if (is.null(sample_rate)) sample_rate = get_sample_rate(x)
 
   null_na = function(x) {
     if (is.null(x)) x = NA


### PR DESCRIPTION
This is after I experienced that get_sample_rate() check for uniqueness of sampling rate observed would fail b/c _**one**_ out of all other values would be different, and the function get_sample_rate() would stop. I think we do not want that, especially given sampling rate is only used in header metadata in ActiGraph-like looking file   